### PR TITLE
fix: extra section in migration for state access; adding @property decorator for direct state access

### DIFF
--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -120,11 +120,11 @@ print(global_response.int1)  # 42
 print(global_response.bytes1.as_str)  # "test"
 
 # Local state required opt-in first
-client.opt_in_opt_in()
+client.send.opt_in.some_opt_in_method()
 local_response = client.get_local_state(account=None)
 print(local_response.local_int1)  # 123
 
-# Box state required manual transactions
+# No unified box state access ;(
 ```
 
 **After (v2):**

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -109,6 +109,48 @@ client, result = factory.deploy(
 )
 ```
 
+### 5. State Access
+
+**Before (v1):**
+
+```python
+# Global state access via dedicated method
+global_response = client.get_global_state()
+print(global_response.int1)  # 42
+print(global_response.bytes1.as_str)  # "test"
+
+# Local state required opt-in first
+client.opt_in_opt_in()
+local_response = client.get_local_state(account=None)
+print(local_response.local_int1)  # 123
+
+# Box state required manual transactions
+```
+
+**After (v2):**
+
+```python
+# Single entry point via .state property
+global_state = client.state.global_state.get_all()
+print(global_state["int1"])  # 42 (native int)
+print(global_state["bytes1"].decode())  # "test"
+## or access key directly via property
+print(client.state.global_state.int1)
+print(client.state.global_state.bytes1.decode())
+
+# Explicit account for local state
+local_state = client.state.local_state("ADDRESS").get_all()
+print(local_state["local_int1"])  # 123
+## or access key directly via property
+print(client.state.local_state("ADDRESS").local_int1)
+
+# Box access via same interface
+box_key = client.state.boxes.box_key # access box key directly
+all_boxes = client.state.boxes.get_all() # access all boxes
+box_mapping = client.state.boxes.box_map.get_map() # access map directly
+box_mapping_content = client.state.boxes.box_map.get_value(Inputs(add=InputsAdd(a=1, b=2), subtract=InputsSubtract(a=4, b=3))) # access map content directly by typed key
+```
+
 ## Key Improvements
 
 | Feature          | v1              | v2 Benefit                   |
@@ -136,7 +178,3 @@ client, result = factory.deploy(
 -   Combine factory patterns with `algokit-utils-py` v3 features for best results
 
 Need help? Submit an issue on [GitHub](https://github.com/algorandfoundation/algokit-client-generator-py/issues), for reference on the application specification refer to [ARC-56 specification](https://arc.algorand.foundation/ARCs/arc-0056).
-
-```
-
-```

--- a/examples/arc56_test/client.py
+++ b/examples/arc56_test/client.py
@@ -384,12 +384,13 @@ class _GlobalState:
             )
         return typing.cast(GlobalStateValue, converted)
 
+    @property
     def global_key(self) -> int:
-            """Get the current value of the global_key key in global_state state"""
-            value = self.app_client.state.global_state.get_value("global_key")
-            if isinstance(value, dict) and "uint64" in self._struct_classes:
-                return self._struct_classes["uint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the global_key key in global_state state"""
+        value = self.app_client.state.global_state.get_value("global_key")
+        if isinstance(value, dict) and "uint64" in self._struct_classes:
+            return self._struct_classes["uint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
     @property
     def global_map(self) -> "_MapState[str, FooUint16BarUint16]":
@@ -423,12 +424,13 @@ class _LocalState:
             )
         return typing.cast(LocalStateValue, converted)
 
+    @property
     def local_key(self) -> int:
-            """Get the current value of the local_key key in local_state state"""
-            value = self.app_client.state.local_state(self.address).get_value("local_key")
-            if isinstance(value, dict) and "uint64" in self._struct_classes:
-                return self._struct_classes["uint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the local_key key in local_state state"""
+        value = self.app_client.state.local_state(self.address).get_value("local_key")
+        if isinstance(value, dict) and "uint64" in self._struct_classes:
+            return self._struct_classes["uint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
     @property
     def local_map(self) -> "_MapState[bytes, str]":
@@ -464,12 +466,13 @@ class _BoxState:
             )
         return typing.cast(BoxStateValue, converted)
 
+    @property
     def box_key(self) -> str:
-            """Get the current value of the box_key key in box state"""
-            value = self.app_client.state.box.get_value("box_key")
-            if isinstance(value, dict) and "string" in self._struct_classes:
-                return self._struct_classes["string"](**value)  # type: ignore
-            return typing.cast(str, value)
+        """Get the current value of the box_key key in box state"""
+        value = self.app_client.state.box.get_value("box_key")
+        if isinstance(value, dict) and "string" in self._struct_classes:
+            return self._struct_classes["string"](**value)  # type: ignore
+        return typing.cast(str, value)
 
     @property
     def box_map(self) -> "_MapState[Inputs, Outputs]":

--- a/examples/arc56_test/test_client.py
+++ b/examples/arc56_test/test_client.py
@@ -147,8 +147,8 @@ def test_arc56_demo(
             )
         )
 
-    assert client.state.global_state.global_key() == 1337
-    assert another_client.state.global_state.global_key() == 1338
+    assert client.state.global_state.global_key == 1337
+    assert another_client.state.global_state.global_key == 1338
     assert client.state.global_state.global_map.get_value("foo") == FooUint16BarUint16(
         foo=13, bar=37
     )
@@ -159,13 +159,13 @@ def test_arc56_demo(
     client.send.opt_in.opt_in_to_application(
         send_params={"populate_app_call_resources": True}
     )
-
-    assert client.state.local_state(default_deployer.address).local_key() == 1337
+    assert client.state.local_state(default_deployer.address).local_key == 1337
     assert (
         client.state.local_state(default_deployer.address).local_map.get_value(b"foo")
         == "bar"
     )
-    assert client.state.box.box_key() == "baz"
+    client.state.box.box_map.get_value
+    assert client.state.box.box_key == "baz"
     assert client.state.box.box_map.get_value(
         Inputs(add=InputsAdd(a=1, b=2), subtract=InputsSubtract(a=4, b=3))
     ) == Outputs(

--- a/examples/global_state_struct/client.py
+++ b/examples/global_state_struct/client.py
@@ -240,12 +240,13 @@ class _GlobalState:
             )
         return typing.cast(GlobalStateValue, converted)
 
+    @property
     def my_struct(self) -> Vector:
-            """Get the current value of the my_struct key in global_state state"""
-            value = self.app_client.state.global_state.get_value("my_struct")
-            if isinstance(value, dict) and "Vector" in self._struct_classes:
-                return self._struct_classes["Vector"](**value)  # type: ignore
-            return typing.cast(Vector, value)
+        """Get the current value of the my_struct key in global_state state"""
+        value = self.app_client.state.global_state.get_value("my_struct")
+        if isinstance(value, dict) and "Vector" in self._struct_classes:
+            return self._struct_classes["Vector"](**value)  # type: ignore
+        return typing.cast(Vector, value)
 
 class HelloWorldClient:
     """Client for interacting with HelloWorld smart contract"""

--- a/examples/lifecycle/client.py
+++ b/examples/lifecycle/client.py
@@ -410,19 +410,21 @@ class _GlobalState:
             )
         return typing.cast(GlobalStateValue, converted)
 
+    @property
     def greeting(self) -> bytes:
-            """Get the current value of the greeting key in global_state state"""
-            value = self.app_client.state.global_state.get_value("greeting")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the greeting key in global_state state"""
+        value = self.app_client.state.global_state.get_value("greeting")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def times(self) -> int:
-            """Get the current value of the times key in global_state state"""
-            value = self.app_client.state.global_state.get_value("times")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the times key in global_state state"""
+        value = self.app_client.state.global_state.get_value("times")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
 class LifeCycleAppClient:
     """Client for interacting with LifeCycleApp smart contract"""

--- a/examples/reti/client.py
+++ b/examples/reti/client.py
@@ -1880,33 +1880,37 @@ class _GlobalState:
             )
         return typing.cast(GlobalStateValue, converted)
 
+    @property
     def staking_pool_initialized(self) -> bool:
-            """Get the current value of the staking_pool_initialized key in global_state state"""
-            value = self.app_client.state.global_state.get_value("staking_pool_initialized")
-            if isinstance(value, dict) and "bool" in self._struct_classes:
-                return self._struct_classes["bool"](**value)  # type: ignore
-            return typing.cast(bool, value)
+        """Get the current value of the staking_pool_initialized key in global_state state"""
+        value = self.app_client.state.global_state.get_value("staking_pool_initialized")
+        if isinstance(value, dict) and "bool" in self._struct_classes:
+            return self._struct_classes["bool"](**value)  # type: ignore
+        return typing.cast(bool, value)
 
+    @property
     def num_validators(self) -> int:
-            """Get the current value of the num_validators key in global_state state"""
-            value = self.app_client.state.global_state.get_value("num_validators")
-            if isinstance(value, dict) and "uint64" in self._struct_classes:
-                return self._struct_classes["uint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the num_validators key in global_state state"""
+        value = self.app_client.state.global_state.get_value("num_validators")
+        if isinstance(value, dict) and "uint64" in self._struct_classes:
+            return self._struct_classes["uint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def num_stakers(self) -> int:
-            """Get the current value of the num_stakers key in global_state state"""
-            value = self.app_client.state.global_state.get_value("num_stakers")
-            if isinstance(value, dict) and "uint64" in self._struct_classes:
-                return self._struct_classes["uint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the num_stakers key in global_state state"""
+        value = self.app_client.state.global_state.get_value("num_stakers")
+        if isinstance(value, dict) and "uint64" in self._struct_classes:
+            return self._struct_classes["uint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def total_algo_staked(self) -> int:
-            """Get the current value of the total_algo_staked key in global_state state"""
-            value = self.app_client.state.global_state.get_value("total_algo_staked")
-            if isinstance(value, dict) and "uint64" in self._struct_classes:
-                return self._struct_classes["uint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the total_algo_staked key in global_state state"""
+        value = self.app_client.state.global_state.get_value("total_algo_staked")
+        if isinstance(value, dict) and "uint64" in self._struct_classes:
+            return self._struct_classes["uint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
 class _BoxState:
     def __init__(self, app_client: algokit_utils.AppClient):
@@ -1933,12 +1937,13 @@ class _BoxState:
             )
         return typing.cast(BoxStateValue, converted)
 
+    @property
     def staking_pool_approval_program(self) -> bytes:
-            """Get the current value of the staking_pool_approval_program key in box state"""
-            value = self.app_client.state.box.get_value("staking_pool_approval_program")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the staking_pool_approval_program key in box state"""
+        value = self.app_client.state.box.get_value("staking_pool_approval_program")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
     @property
     def validator_list(self) -> "_MapState[int, ValidatorInfo]":

--- a/examples/state/client.py
+++ b/examples/state/client.py
@@ -1256,40 +1256,45 @@ class _GlobalState:
             )
         return typing.cast(GlobalStateValue, converted)
 
+    @property
     def bytes1(self) -> bytes:
-            """Get the current value of the bytes1 key in global_state state"""
-            value = self.app_client.state.global_state.get_value("bytes1")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the bytes1 key in global_state state"""
+        value = self.app_client.state.global_state.get_value("bytes1")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def bytes2(self) -> bytes:
-            """Get the current value of the bytes2 key in global_state state"""
-            value = self.app_client.state.global_state.get_value("bytes2")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the bytes2 key in global_state state"""
+        value = self.app_client.state.global_state.get_value("bytes2")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def int1(self) -> int:
-            """Get the current value of the int1 key in global_state state"""
-            value = self.app_client.state.global_state.get_value("int1")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the int1 key in global_state state"""
+        value = self.app_client.state.global_state.get_value("int1")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def int2(self) -> int:
-            """Get the current value of the int2 key in global_state state"""
-            value = self.app_client.state.global_state.get_value("int2")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the int2 key in global_state state"""
+        value = self.app_client.state.global_state.get_value("int2")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def value(self) -> int:
-            """Get the current value of the value key in global_state state"""
-            value = self.app_client.state.global_state.get_value("value")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the value key in global_state state"""
+        value = self.app_client.state.global_state.get_value("value")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
 class _LocalState:
     def __init__(self, app_client: algokit_utils.AppClient, address: str):
@@ -1314,33 +1319,37 @@ class _LocalState:
             )
         return typing.cast(LocalStateValue, converted)
 
+    @property
     def local_bytes1(self) -> bytes:
-            """Get the current value of the local_bytes1 key in local_state state"""
-            value = self.app_client.state.local_state(self.address).get_value("local_bytes1")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the local_bytes1 key in local_state state"""
+        value = self.app_client.state.local_state(self.address).get_value("local_bytes1")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def local_bytes2(self) -> bytes:
-            """Get the current value of the local_bytes2 key in local_state state"""
-            value = self.app_client.state.local_state(self.address).get_value("local_bytes2")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the local_bytes2 key in local_state state"""
+        value = self.app_client.state.local_state(self.address).get_value("local_bytes2")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def local_int1(self) -> int:
-            """Get the current value of the local_int1 key in local_state state"""
-            value = self.app_client.state.local_state(self.address).get_value("local_int1")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the local_int1 key in local_state state"""
+        value = self.app_client.state.local_state(self.address).get_value("local_int1")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def local_int2(self) -> int:
-            """Get the current value of the local_int2 key in local_state state"""
-            value = self.app_client.state.local_state(self.address).get_value("local_int2")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the local_int2 key in local_state state"""
+        value = self.app_client.state.local_state(self.address).get_value("local_int2")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
 class StateAppClient:
     """Client for interacting with StateApp smart contract"""

--- a/examples/state/test_client.py
+++ b/examples/state/test_client.py
@@ -61,6 +61,8 @@ def test_exposes_state_correctly(
         args=SetGlobalArgs(int1=1, bytes1="asdf", bytes2=b"\x01\x02\x03\x04", int2=2)
     )
     global_state = client.state.global_state.get_all()
+    client.state.global_state.bytes1
+    
     assert global_state["int1"] == 1
     assert global_state["int2"] == 2
     assert global_state["bytes1"] == b"asdf"

--- a/examples/state/test_client.py
+++ b/examples/state/test_client.py
@@ -61,7 +61,6 @@ def test_exposes_state_correctly(
         args=SetGlobalArgs(int1=1, bytes1="asdf", bytes2=b"\x01\x02\x03\x04", int2=2)
     )
     global_state = client.state.global_state.get_all()
-    client.state.global_state.bytes1
     
     assert global_state["int1"] == 1
     assert global_state["int2"] == 2

--- a/examples/voting/client.py
+++ b/examples/voting/client.py
@@ -485,96 +485,109 @@ class _GlobalState:
             )
         return typing.cast(GlobalStateValue, converted)
 
+    @property
     def close_time(self) -> int:
-            """Get the current value of the close_time key in global_state state"""
-            value = self.app_client.state.global_state.get_value("close_time")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the close_time key in global_state state"""
+        value = self.app_client.state.global_state.get_value("close_time")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def end_time(self) -> int:
-            """Get the current value of the end_time key in global_state state"""
-            value = self.app_client.state.global_state.get_value("end_time")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the end_time key in global_state state"""
+        value = self.app_client.state.global_state.get_value("end_time")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def is_bootstrapped(self) -> int:
-            """Get the current value of the is_bootstrapped key in global_state state"""
-            value = self.app_client.state.global_state.get_value("is_bootstrapped")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the is_bootstrapped key in global_state state"""
+        value = self.app_client.state.global_state.get_value("is_bootstrapped")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def metadata_ipfs_cid(self) -> bytes:
-            """Get the current value of the metadata_ipfs_cid key in global_state state"""
-            value = self.app_client.state.global_state.get_value("metadata_ipfs_cid")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the metadata_ipfs_cid key in global_state state"""
+        value = self.app_client.state.global_state.get_value("metadata_ipfs_cid")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def nft_asset_id(self) -> int:
-            """Get the current value of the nft_asset_id key in global_state state"""
-            value = self.app_client.state.global_state.get_value("nft_asset_id")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the nft_asset_id key in global_state state"""
+        value = self.app_client.state.global_state.get_value("nft_asset_id")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def nft_image_url(self) -> bytes:
-            """Get the current value of the nft_image_url key in global_state state"""
-            value = self.app_client.state.global_state.get_value("nft_image_url")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the nft_image_url key in global_state state"""
+        value = self.app_client.state.global_state.get_value("nft_image_url")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def option_counts(self) -> bytes:
-            """Get the current value of the option_counts key in global_state state"""
-            value = self.app_client.state.global_state.get_value("option_counts")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the option_counts key in global_state state"""
+        value = self.app_client.state.global_state.get_value("option_counts")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def quorum(self) -> int:
-            """Get the current value of the quorum key in global_state state"""
-            value = self.app_client.state.global_state.get_value("quorum")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the quorum key in global_state state"""
+        value = self.app_client.state.global_state.get_value("quorum")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def snapshot_public_key(self) -> bytes:
-            """Get the current value of the snapshot_public_key key in global_state state"""
-            value = self.app_client.state.global_state.get_value("snapshot_public_key")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the snapshot_public_key key in global_state state"""
+        value = self.app_client.state.global_state.get_value("snapshot_public_key")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def start_time(self) -> int:
-            """Get the current value of the start_time key in global_state state"""
-            value = self.app_client.state.global_state.get_value("start_time")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the start_time key in global_state state"""
+        value = self.app_client.state.global_state.get_value("start_time")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def total_options(self) -> int:
-            """Get the current value of the total_options key in global_state state"""
-            value = self.app_client.state.global_state.get_value("total_options")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the total_options key in global_state state"""
+        value = self.app_client.state.global_state.get_value("total_options")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def vote_id(self) -> bytes:
-            """Get the current value of the vote_id key in global_state state"""
-            value = self.app_client.state.global_state.get_value("vote_id")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the vote_id key in global_state state"""
+        value = self.app_client.state.global_state.get_value("vote_id")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def voter_count(self) -> int:
-            """Get the current value of the voter_count key in global_state state"""
-            value = self.app_client.state.global_state.get_value("voter_count")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the voter_count key in global_state state"""
+        value = self.app_client.state.global_state.get_value("voter_count")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
 class VotingRoundAppClient:
     """Client for interacting with VotingRoundApp smart contract"""

--- a/examples/zero_coupon_bond/client.py
+++ b/examples/zero_coupon_bond/client.py
@@ -1255,138 +1255,157 @@ class _GlobalState:
             )
         return typing.cast(GlobalStateValue, converted)
 
+    @property
     def arranger(self) -> bytes:
-            """Get the current value of the arranger key in global_state state"""
-            value = self.app_client.state.global_state.get_value("arranger")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the arranger key in global_state state"""
+        value = self.app_client.state.global_state.get_value("arranger")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def denomination_asset_id(self) -> int:
-            """Get the current value of the denomination_asset_id key in global_state state"""
-            value = self.app_client.state.global_state.get_value("denomination_asset_id")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the denomination_asset_id key in global_state state"""
+        value = self.app_client.state.global_state.get_value("denomination_asset_id")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def settlement_asset_id(self) -> int:
-            """Get the current value of the settlement_asset_id key in global_state state"""
-            value = self.app_client.state.global_state.get_value("settlement_asset_id")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the settlement_asset_id key in global_state state"""
+        value = self.app_client.state.global_state.get_value("settlement_asset_id")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def unit_value(self) -> int:
-            """Get the current value of the unit_value key in global_state state"""
-            value = self.app_client.state.global_state.get_value("unit_value")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the unit_value key in global_state state"""
+        value = self.app_client.state.global_state.get_value("unit_value")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def day_count_convention(self) -> int:
-            """Get the current value of the day_count_convention key in global_state state"""
-            value = self.app_client.state.global_state.get_value("day_count_convention")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the day_count_convention key in global_state state"""
+        value = self.app_client.state.global_state.get_value("day_count_convention")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def metadata(self) -> bytes:
-            """Get the current value of the metadata key in global_state state"""
-            value = self.app_client.state.global_state.get_value("metadata")
-            if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
-                return self._struct_classes["AVMBytes"](**value)  # type: ignore
-            return typing.cast(bytes, value)
+        """Get the current value of the metadata key in global_state state"""
+        value = self.app_client.state.global_state.get_value("metadata")
+        if isinstance(value, dict) and "AVMBytes" in self._struct_classes:
+            return self._struct_classes["AVMBytes"](**value)  # type: ignore
+        return typing.cast(bytes, value)
 
+    @property
     def total_units(self) -> int:
-            """Get the current value of the total_units key in global_state state"""
-            value = self.app_client.state.global_state.get_value("total_units")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the total_units key in global_state state"""
+        value = self.app_client.state.global_state.get_value("total_units")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def circulating_units(self) -> int:
-            """Get the current value of the circulating_units key in global_state state"""
-            value = self.app_client.state.global_state.get_value("circulating_units")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the circulating_units key in global_state state"""
+        value = self.app_client.state.global_state.get_value("circulating_units")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def interest_rate(self) -> int:
-            """Get the current value of the interest_rate key in global_state state"""
-            value = self.app_client.state.global_state.get_value("interest_rate")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the interest_rate key in global_state state"""
+        value = self.app_client.state.global_state.get_value("interest_rate")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def total_coupons(self) -> int:
-            """Get the current value of the total_coupons key in global_state state"""
-            value = self.app_client.state.global_state.get_value("total_coupons")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the total_coupons key in global_state state"""
+        value = self.app_client.state.global_state.get_value("total_coupons")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def primary_distribution_opening_date(self) -> int:
-            """Get the current value of the primary_distribution_opening_date key in global_state state"""
-            value = self.app_client.state.global_state.get_value("primary_distribution_opening_date")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the primary_distribution_opening_date key in global_state state"""
+        value = self.app_client.state.global_state.get_value("primary_distribution_opening_date")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def primary_distribution_closure_date(self) -> int:
-            """Get the current value of the primary_distribution_closure_date key in global_state state"""
-            value = self.app_client.state.global_state.get_value("primary_distribution_closure_date")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the primary_distribution_closure_date key in global_state state"""
+        value = self.app_client.state.global_state.get_value("primary_distribution_closure_date")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def issuance_date(self) -> int:
-            """Get the current value of the issuance_date key in global_state state"""
-            value = self.app_client.state.global_state.get_value("issuance_date")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the issuance_date key in global_state state"""
+        value = self.app_client.state.global_state.get_value("issuance_date")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def secondary_market_opening_date(self) -> int:
-            """Get the current value of the secondary_market_opening_date key in global_state state"""
-            value = self.app_client.state.global_state.get_value("secondary_market_opening_date")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the secondary_market_opening_date key in global_state state"""
+        value = self.app_client.state.global_state.get_value("secondary_market_opening_date")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def secondary_market_closure_date(self) -> int:
-            """Get the current value of the secondary_market_closure_date key in global_state state"""
-            value = self.app_client.state.global_state.get_value("secondary_market_closure_date")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the secondary_market_closure_date key in global_state state"""
+        value = self.app_client.state.global_state.get_value("secondary_market_closure_date")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def maturity_date(self) -> int:
-            """Get the current value of the maturity_date key in global_state state"""
-            value = self.app_client.state.global_state.get_value("maturity_date")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the maturity_date key in global_state state"""
+        value = self.app_client.state.global_state.get_value("maturity_date")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def status(self) -> int:
-            """Get the current value of the status key in global_state state"""
-            value = self.app_client.state.global_state.get_value("status")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the status key in global_state state"""
+        value = self.app_client.state.global_state.get_value("status")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def suspended(self) -> int:
-            """Get the current value of the suspended key in global_state state"""
-            value = self.app_client.state.global_state.get_value("suspended")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the suspended key in global_state state"""
+        value = self.app_client.state.global_state.get_value("suspended")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
+    @property
     def defaulted(self) -> int:
-            """Get the current value of the defaulted key in global_state state"""
-            value = self.app_client.state.global_state.get_value("defaulted")
-            if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
-                return self._struct_classes["AVMUint64"](**value)  # type: ignore
-            return typing.cast(int, value)
+        """Get the current value of the defaulted key in global_state state"""
+        value = self.app_client.state.global_state.get_value("defaulted")
+        if isinstance(value, dict) and "AVMUint64" in self._struct_classes:
+            return self._struct_classes["AVMUint64"](**value)  # type: ignore
+        return typing.cast(int, value)
 
 class _BoxState:
     def __init__(self, app_client: algokit_utils.AppClient):
@@ -1414,26 +1433,29 @@ class _BoxState:
             )
         return typing.cast(BoxStateValue, converted)
 
+    @property
     def coupon_rates(self) -> list[int]:
-            """Get the current value of the coupon_rates key in box state"""
-            value = self.app_client.state.box.get_value("coupon_rates")
-            if isinstance(value, dict) and "uint16[]" in self._struct_classes:
-                return self._struct_classes["uint16[]"](**value)  # type: ignore
-            return typing.cast(list[int], value)
+        """Get the current value of the coupon_rates key in box state"""
+        value = self.app_client.state.box.get_value("coupon_rates")
+        if isinstance(value, dict) and "uint16[]" in self._struct_classes:
+            return self._struct_classes["uint16[]"](**value)  # type: ignore
+        return typing.cast(list[int], value)
 
+    @property
     def time_events(self) -> list[int]:
-            """Get the current value of the time_events key in box state"""
-            value = self.app_client.state.box.get_value("time_events")
-            if isinstance(value, dict) and "uint64[]" in self._struct_classes:
-                return self._struct_classes["uint64[]"](**value)  # type: ignore
-            return typing.cast(list[int], value)
+        """Get the current value of the time_events key in box state"""
+        value = self.app_client.state.box.get_value("time_events")
+        if isinstance(value, dict) and "uint64[]" in self._struct_classes:
+            return self._struct_classes["uint64[]"](**value)  # type: ignore
+        return typing.cast(list[int], value)
 
+    @property
     def time_periods(self) -> list[tuple[int, int]]:
-            """Get the current value of the time_periods key in box state"""
-            value = self.app_client.state.box.get_value("time_periods")
-            if isinstance(value, dict) and "(uint64,uint64)[]" in self._struct_classes:
-                return self._struct_classes["(uint64,uint64)[]"](**value)  # type: ignore
-            return typing.cast(list[tuple[int, int]], value)
+        """Get the current value of the time_periods key in box state"""
+        value = self.app_client.state.box.get_value("time_periods")
+        if isinstance(value, dict) and "(uint64,uint64)[]" in self._struct_classes:
+            return self._struct_classes["(uint64,uint64)[]"](**value)  # type: ignore
+        return typing.cast(list[tuple[int, int]], value)
 
     @property
     def account_manager(self) -> "_MapState[str, RoleConfig]":

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,12 +2,12 @@
 
 [[package]]
 name = "algokit-utils"
-version = "3.0.0b2"
+version = "3.0.0b3"
 description = "Utilities for Algorand development for use by AlgoKit"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "algokit_utils-3.0.0b2-py3-none-any.whl", hash = "sha256:661a0225393b2d868b76b1c5d71ab256187b39334ef90a692217b0c8bc88aaf3"},
+    {file = "algokit_utils-3.0.0b3-py3-none-any.whl", hash = "sha256:10b1bf26f2a81747ae4990b328c394070c2725778bbf0997661adfdf91ab60be"},
 ]
 
 [package.dependencies]
@@ -2046,4 +2046,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "814e4d43fedbb02f8bf160daa5d5de37374ee1b004acd5c2abd348679d4ae25c"
+content-hash = "897e54af4048df7527c47dc2a938ef6eca7c10bd043caf87567312bc0a4be535"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-algokit-utils = "^3.0.0b2"
+algokit-utils = "^3.0.0b3"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.8.6"

--- a/src/algokit_client_generator/generators/typed_client.py
+++ b/src/algokit_client_generator/generators/typed_client.py
@@ -843,14 +843,16 @@ class {class_name}:
             python_type = utils.map_abi_type_to_python(key_info.value_type, utils.IOType.OUTPUT, context.structs)
             yield Part.Gap1
             yield Part.IncIndent
-            yield utils.indented(f"""
+            yield (
+                f"""@property
     def {utils.get_method_name(key_name)}(self) -> {python_type}:
         \"\"\"Get the current value of the {key_name} key in {state_type} state\"\"\"
         value = self.app_client.state.{state_type}{'(self.address)' if extra_params else ''}.get_value("{key_name}")
         if isinstance(value, dict) and "{key_info.value_type}" in self._struct_classes:
             return self._struct_classes["{key_info.value_type}"](**value)  # type: ignore
         return typing.cast({python_type}, value)
-""")
+"""
+            )
             yield Part.DecIndent
 
     # Generate methods for maps


### PR DESCRIPTION
## Proposed changes

Addressing feedback on beta version:
- Adding property decorator to access state related key/values. In case of typescript it had to resort to methods while in python a property might be more applicable and will reduce # of breaking changes as this was the approach in previous v1 of generators
- Added extra section on state access 