### PR TITLE
fix: minor patches in dataclass inheritance; fixes for mypy errors; addressing internal feedback 

### DIFF
--- a/examples/arc56_test/client.py
+++ b/examples/arc56_test/client.py
@@ -100,6 +100,10 @@ class FooArgs:
     """Dataclass for foo arguments"""
     inputs: Inputs
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "foo(((uint64,uint64),(uint64,uint64)))(uint64,uint64)"
+
 
 class _Arc56TestOptIn:
     def __init__(self, app_client: algokit_utils.AppClient):
@@ -679,17 +683,19 @@ class Arc56TestClient:
 class Arc56TestMethodCallCreateParams(
     algokit_utils.AppClientCreateSchema, algokit_utils.BaseAppClientMethodCallParams[
         typing.Any,
-        typing.Any,
+        str | None,
     ]
 ):
     """Parameters for creating Arc56Test contract using ABI"""
     on_complete: typing.Literal[OnComplete.NoOpOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallCreateParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallCreateParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )

--- a/examples/arc56_test/client.py
+++ b/examples/arc56_test/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -911,7 +911,7 @@ class Arc56TestFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class Arc56TestFactoryDeleteParams:
@@ -929,7 +929,7 @@ class Arc56TestFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/duplicate_structs/client.py
+++ b/examples/duplicate_structs/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -584,7 +584,7 @@ class DuplicateStructsContractFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class DuplicateStructsContractFactoryDeleteParams:
@@ -602,7 +602,7 @@ class DuplicateStructsContractFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/helloworld/client.py
+++ b/examples/helloworld/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -498,7 +498,7 @@ class HelloWorldAppBareCallCreateParams(algokit_utils.AppClientBareCallCreatePar
         return algokit_utils.AppClientBareCallCreateParams(**self.__dict__)
 
 @dataclasses.dataclass(frozen=True)
-class HelloWorldAppBareCallUpdateParams(algokit_utils.AppClientBareCallCreateParams):
+class HelloWorldAppBareCallUpdateParams(algokit_utils.AppClientBareCallParams):
     """Parameters for calling HelloWorldApp contract with bare calls"""
     on_complete: typing.Literal[OnComplete.UpdateApplicationOC] | None = None
 
@@ -506,7 +506,7 @@ class HelloWorldAppBareCallUpdateParams(algokit_utils.AppClientBareCallCreatePar
         return algokit_utils.AppClientBareCallParams(**self.__dict__)
 
 @dataclasses.dataclass(frozen=True)
-class HelloWorldAppBareCallDeleteParams(algokit_utils.AppClientBareCallCreateParams):
+class HelloWorldAppBareCallDeleteParams(algokit_utils.AppClientBareCallParams):
     """Parameters for calling HelloWorldApp contract with bare calls"""
     on_complete: typing.Literal[OnComplete.DeleteApplicationOC] | None = None
 
@@ -712,7 +712,7 @@ class HelloWorldAppFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class HelloWorldAppFactoryDeleteParams:
@@ -730,7 +730,7 @@ class HelloWorldAppFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/helloworld/client.py
+++ b/examples/helloworld/client.py
@@ -69,10 +69,18 @@ class HelloArgs:
     """Dataclass for hello arguments"""
     name: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "hello(string)string"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class HelloWorldCheckArgs:
     """Dataclass for hello_world_check arguments"""
     name: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "hello_world_check(string)void"
 
 
 class _HelloWorldAppUpdate:

--- a/examples/lifecycle/client.py
+++ b/examples/lifecycle/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -617,7 +617,7 @@ class LifeCycleAppBareCallCreateParams(algokit_utils.AppClientBareCallCreatePara
         return algokit_utils.AppClientBareCallCreateParams(**self.__dict__)
 
 @dataclasses.dataclass(frozen=True)
-class LifeCycleAppBareCallUpdateParams(algokit_utils.AppClientBareCallCreateParams):
+class LifeCycleAppBareCallUpdateParams(algokit_utils.AppClientBareCallParams):
     """Parameters for calling LifeCycleApp contract with bare calls"""
     on_complete: typing.Literal[OnComplete.UpdateApplicationOC] | None = None
 
@@ -862,7 +862,7 @@ class LifeCycleAppFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class LifeCycleAppFactoryDeleteParams:
@@ -880,7 +880,7 @@ class LifeCycleAppFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/lifecycle/client.py
+++ b/examples/lifecycle/client.py
@@ -69,16 +69,28 @@ class HelloStringStringArgs:
     """Dataclass for hello_string_string arguments"""
     name: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "hello(string)string"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CreateStringStringArgs:
     """Dataclass for create_string_string arguments"""
     greeting: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "create(string)string"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CreateStringUint32VoidArgs:
     """Dataclass for create_string_uint32_void arguments"""
     greeting: str
     times: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "create(string,uint32)void"
 
 
 class _LifeCycleAppUpdate:
@@ -592,18 +604,20 @@ class LifeCycleAppClient:
 @dataclasses.dataclass(frozen=True)
 class LifeCycleAppMethodCallCreateParams(
     algokit_utils.AppClientCreateSchema, algokit_utils.BaseAppClientMethodCallParams[
-        tuple[str] | CreateStringStringArgs | tuple[str, int] | CreateStringUint32VoidArgs,
-        typing.Literal["create(string)string"] | typing.Literal["create(string,uint32)void"],
+        CreateStringStringArgs | CreateStringUint32VoidArgs,
+        str | None,
     ]
 ):
     """Parameters for creating LifeCycleApp contract using ABI"""
     on_complete: typing.Literal[OnComplete.NoOpOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallCreateParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallCreateParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )

--- a/examples/lifecycle/test_client.py
+++ b/examples/lifecycle/test_client.py
@@ -93,8 +93,7 @@ def test_create_2arg(lifecycle_factory: LifeCycleAppFactory) -> None:
 def test_deploy_create_1arg(lifecycle_factory: LifeCycleAppFactory) -> None:
     client, response = lifecycle_factory.deploy(
         create_params=LifeCycleAppMethodCallCreateParams(
-            args=CreateStringStringArgs(greeting="greeting"),
-            method="create(string)string",
+            args=CreateStringStringArgs(greeting="greeting")
         )
     )
 

--- a/examples/minimal/client.py
+++ b/examples/minimal/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -384,7 +384,7 @@ class AppBareCallCreateParams(algokit_utils.AppClientBareCallCreateParams):
         return algokit_utils.AppClientBareCallCreateParams(**self.__dict__)
 
 @dataclasses.dataclass(frozen=True)
-class AppBareCallUpdateParams(algokit_utils.AppClientBareCallCreateParams):
+class AppBareCallUpdateParams(algokit_utils.AppClientBareCallParams):
     """Parameters for calling App contract with bare calls"""
     on_complete: typing.Literal[OnComplete.UpdateApplicationOC] | None = None
 
@@ -392,7 +392,7 @@ class AppBareCallUpdateParams(algokit_utils.AppClientBareCallCreateParams):
         return algokit_utils.AppClientBareCallParams(**self.__dict__)
 
 @dataclasses.dataclass(frozen=True)
-class AppBareCallDeleteParams(algokit_utils.AppClientBareCallCreateParams):
+class AppBareCallDeleteParams(algokit_utils.AppClientBareCallParams):
     """Parameters for calling App contract with bare calls"""
     on_complete: typing.Literal[OnComplete.DeleteApplicationOC] | None = None
 
@@ -558,7 +558,7 @@ class AppFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class AppFactoryDeleteParams:
@@ -576,7 +576,7 @@ class AppFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/nested/client.py
+++ b/examples/nested/client.py
@@ -70,10 +70,18 @@ class AddArgs:
     a: int
     b: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "add(uint64,uint64)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetPayTxnAmountArgs:
     """Dataclass for get_pay_txn_amount arguments"""
     pay_txn: algokit_utils.AppMethodCallTransactionArgument
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "get_pay_txn_amount(pay)uint64"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class NestedMethodCallArgs:
@@ -81,6 +89,10 @@ class NestedMethodCallArgs:
     _: str
     _pay_txn: algokit_utils.AppMethodCallTransactionArgument | None = None
     method_call: algokit_utils.AppMethodCallTransactionArgument
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "nested_method_call(string,pay,appl)byte[]"
 
 
 class NestedContractParams:

--- a/examples/nested/client.py
+++ b/examples/nested/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -678,7 +678,7 @@ class NestedContractFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class NestedContractFactoryDeleteParams:
@@ -696,7 +696,7 @@ class NestedContractFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/nfd/client.py
+++ b/examples/nfd/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -2529,7 +2529,7 @@ class NfdInstanceFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class NfdInstanceFactoryDeleteParams:
@@ -2547,7 +2547,7 @@ class NfdInstanceFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/nfd/client.py
+++ b/examples/nfd/client.py
@@ -80,10 +80,18 @@ class MintAsaArgs:
     nfdName: str
     url: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "mintAsa(string,string)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DeleteFieldsArgs:
     """Dataclass for delete_fields arguments"""
     fieldNames: list[bytes | str]
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "deleteFields(byte[][])void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class UpdateSegmentCountArgs:
@@ -91,20 +99,36 @@ class UpdateSegmentCountArgs:
     childNfdName: str
     childNfdAppID: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "updateSegmentCount(string,uint64)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetFieldUpdateCostArgs:
     """Dataclass for get_field_update_cost arguments"""
     fieldAndVals: list[bytes | str]
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "getFieldUpdateCost(byte[][])uint64"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class UpdateFieldsArgs:
     """Dataclass for update_fields arguments"""
     fieldAndVals: list[bytes | str]
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "updateFields(byte[][])void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ReadFieldArgs:
     """Dataclass for read_field arguments"""
     fieldName: bytes | str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "readField(byte[])byte[]"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class OfferForSaleArgs:
@@ -112,11 +136,19 @@ class OfferForSaleArgs:
     sellAmount: int
     reservedFor: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "offerForSale(uint64,address)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class PostOfferArgs:
     """Dataclass for post_offer arguments"""
     offer: int
     note: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "postOffer(uint64,string)void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class MintPayoutArgs:
@@ -124,10 +156,18 @@ class MintPayoutArgs:
     oneYearPrice: int
     segmentPlatformCostInAlgo: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "mintPayout(uint64,uint64)(uint64,address,uint64,address,uint64)"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class PurchaseArgs:
     """Dataclass for purchase arguments"""
     payment: algokit_utils.AppMethodCallTransactionArgument
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "purchase(pay)void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class IsAddressInFieldArgs:
@@ -135,15 +175,27 @@ class IsAddressInFieldArgs:
     fieldName: str
     address: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "isAddressInField(string,address)bool"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class UpdateHashArgs:
     """Dataclass for update_hash arguments"""
     hash: bytes | str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "updateHash(byte[])void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ContractLockArgs:
     """Dataclass for contract_lock arguments"""
     lock: bool
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "contractLock(bool)void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SegmentLockArgs:
@@ -151,15 +203,27 @@ class SegmentLockArgs:
     lock: bool
     usdPrice: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "segmentLock(bool,uint64)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class VaultOptInLockArgs:
     """Dataclass for vault_opt_in_lock arguments"""
     lock: bool
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "vaultOptInLock(bool)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class VaultOptInArgs:
     """Dataclass for vault_opt_in arguments"""
     assets: list[int]
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "vaultOptIn(uint64[])void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class VaultSendArgs:
@@ -170,10 +234,18 @@ class VaultSendArgs:
     asset: int
     otherAssets: list[int]
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "vaultSend(uint64,address,string,uint64,uint64[])void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class RenewArgs:
     """Dataclass for renew arguments"""
     payment: algokit_utils.AppMethodCallTransactionArgument
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "renew(pay)void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SetPrimaryAddressArgs:
@@ -181,11 +253,19 @@ class SetPrimaryAddressArgs:
     fieldName: str
     address: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "setPrimaryAddress(string,address)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class RegistryAddingVerifiedAddressArgs:
     """Dataclass for registry_adding_verified_address arguments"""
     fieldBeingVerified: str
     fieldSetName: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "registryAddingVerifiedAddress(string,string)bool"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class RegistryRemovingVerifiedAddressArgs:
@@ -193,6 +273,10 @@ class RegistryRemovingVerifiedAddressArgs:
     fieldBeingChanged: str
     address: str
     mbrRefundDest: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "registryRemovingVerifiedAddress(string,address,address)bool"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CreateApplicationArgs:
@@ -209,10 +293,18 @@ class CreateApplicationArgs:
     segmentRootAppId: int
     segmentRootCommissionAddr: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "createApplication(string,address,address,uint64,uint64,address,uint64,address,uint64,uint64,address)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class UpdateApplicationArgs:
     """Dataclass for update_application arguments"""
     versionNum: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "updateApplication(string)void"
 
 
 class _NfdInstanceUpdate:
@@ -1818,18 +1910,20 @@ class NfdInstanceClient:
 @dataclasses.dataclass(frozen=True)
 class NfdInstanceMethodCallCreateParams(
     algokit_utils.AppClientCreateSchema, algokit_utils.BaseAppClientMethodCallParams[
-        tuple[str, str, str, int, int, str, int, str, int, int, str] | CreateApplicationArgs,
-        typing.Literal["createApplication(string,address,address,uint64,uint64,address,uint64,address,uint64,uint64,address)void"],
+        CreateApplicationArgs,
+        str | None,
     ]
 ):
     """Parameters for creating NfdInstance contract using ABI"""
     on_complete: typing.Literal[OnComplete.NoOpOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallCreateParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallCreateParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )
@@ -1837,18 +1931,20 @@ class NfdInstanceMethodCallCreateParams(
 @dataclasses.dataclass(frozen=True)
 class NfdInstanceMethodCallUpdateParams(
     algokit_utils.BaseAppClientMethodCallParams[
-        tuple[str] | UpdateApplicationArgs,
-        typing.Literal["updateApplication(string)void"],
+        UpdateApplicationArgs,
+        str | None,
     ]
 ):
     """Parameters for calling NfdInstance contract using ABI"""
     on_complete: typing.Literal[OnComplete.UpdateApplicationOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )

--- a/examples/reti/client.py
+++ b/examples/reti/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -3192,7 +3192,7 @@ class ValidatorRegistryFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class ValidatorRegistryFactoryDeleteParams:
@@ -3210,7 +3210,7 @@ class ValidatorRegistryFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/reti/client.py
+++ b/examples/reti/client.py
@@ -198,31 +198,55 @@ class InitStakingContractArgs:
     """Dataclass for init_staking_contract arguments"""
     approvalProgramSize: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "initStakingContract(uint64)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class LoadStakingContractDataArgs:
     """Dataclass for load_staking_contract_data arguments"""
     offset: int
     data: bytes | str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "loadStakingContractData(uint64,byte[])void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetValidatorConfigArgs:
     """Dataclass for get_validator_config arguments"""
     validatorId: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "getValidatorConfig(uint64)(uint64,address,address,uint64,uint8,address,uint64[4],uint64,uint64,uint64,uint32,uint32,address,uint64,uint64,uint8,uint64,uint64)"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetValidatorStateArgs:
     """Dataclass for get_validator_state arguments"""
     validatorId: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "getValidatorState(uint64)(uint16,uint64,uint64,uint64)"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetValidatorOwnerAndManagerArgs:
     """Dataclass for get_validator_owner_and_manager arguments"""
     validatorId: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "getValidatorOwnerAndManager(uint64)(address,address)"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetPoolsArgs:
     """Dataclass for get_pools arguments"""
     validatorId: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "getPools(uint64)(uint64,uint16,uint64)[]"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetPoolAppIdArgs:
@@ -230,35 +254,63 @@ class GetPoolAppIdArgs:
     validatorId: int
     poolId: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "getPoolAppId(uint64,uint64)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetPoolInfoArgs:
     """Dataclass for get_pool_info arguments"""
     poolKey: ValidatorPoolKey
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "getPoolInfo((uint64,uint64,uint64))(uint64,uint16,uint64)"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetCurMaxStakePerPoolArgs:
     """Dataclass for get_cur_max_stake_per_pool arguments"""
     validatorId: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "getCurMaxStakePerPool(uint64)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DoesStakerNeedToPayMbrArgs:
     """Dataclass for does_staker_need_to_pay_mbr arguments"""
     staker: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "doesStakerNeedToPayMBR(address)bool"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetStakedPoolsForAccountArgs:
     """Dataclass for get_staked_pools_for_account arguments"""
     staker: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "getStakedPoolsForAccount(address)(uint64,uint64,uint64)[]"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetTokenPayoutRatioArgs:
     """Dataclass for get_token_payout_ratio arguments"""
     validatorId: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "getTokenPayoutRatio(uint64)(uint64[24],uint64)"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetNodePoolAssignmentsArgs:
     """Dataclass for get_node_pool_assignments arguments"""
     validatorId: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "getNodePoolAssignments(uint64)((uint64[3])[8])"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class AddValidatorArgs:
@@ -267,11 +319,19 @@ class AddValidatorArgs:
     nfdName: str
     config: ValidatorConfig
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "addValidator(pay,string,(uint64,address,address,uint64,uint8,address,uint64[4],uint64,uint64,uint64,uint32,uint32,address,uint64,uint64,uint8,uint64,uint64))uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ChangeValidatorManagerArgs:
     """Dataclass for change_validator_manager arguments"""
     validatorId: int
     manager: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "changeValidatorManager(uint64,address)void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ChangeValidatorSunsetInfoArgs:
@@ -280,6 +340,10 @@ class ChangeValidatorSunsetInfoArgs:
     sunsettingOn: int
     sunsettingTo: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "changeValidatorSunsetInfo(uint64,uint64,uint64)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ChangeValidatorNfdArgs:
     """Dataclass for change_validator_nfd arguments"""
@@ -287,11 +351,19 @@ class ChangeValidatorNfdArgs:
     nfdAppID: int
     nfdName: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "changeValidatorNFD(uint64,uint64,string)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ChangeValidatorCommissionAddressArgs:
     """Dataclass for change_validator_commission_address arguments"""
     validatorId: int
     commissionAddress: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "changeValidatorCommissionAddress(uint64,address)void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class ChangeValidatorRewardInfoArgs:
@@ -303,12 +375,20 @@ class ChangeValidatorRewardInfoArgs:
     GatingAssetMinBalance: int
     RewardPerPayout: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "changeValidatorRewardInfo(uint64,uint8,address,uint64[4],uint64,uint64)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class AddPoolArgs:
     """Dataclass for add_pool arguments"""
     mbrPayment: algokit_utils.AppMethodCallTransactionArgument
     validatorId: int
     nodeNum: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "addPool(pay,uint64,uint64)(uint64,uint64,uint64)"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class AddStakeArgs:
@@ -317,10 +397,18 @@ class AddStakeArgs:
     validatorId: int
     valueToVerify: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "addStake(pay,uint64,uint64)(uint64,uint64,uint64)"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SetTokenPayoutRatioArgs:
     """Dataclass for set_token_payout_ratio arguments"""
     validatorId: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "setTokenPayoutRatio(uint64)(uint64[24],uint64)"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class StakeUpdatedViaRewardsArgs:
@@ -331,6 +419,10 @@ class StakeUpdatedViaRewardsArgs:
     validatorCommission: int
     saturatedBurnToFeeSink: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "stakeUpdatedViaRewards((uint64,uint64,uint64),uint64,uint64,uint64,uint64)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class StakeRemovedArgs:
     """Dataclass for stake_removed arguments"""
@@ -340,12 +432,20 @@ class StakeRemovedArgs:
     rewardRemoved: int
     stakerRemoved: bool
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "stakeRemoved((uint64,uint64,uint64),address,uint64,uint64,bool)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FindPoolForStakerArgs:
     """Dataclass for find_pool_for_staker arguments"""
     validatorId: int
     staker: str
     amountToStake: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "findPoolForStaker(uint64,address,uint64)((uint64,uint64,uint64),bool,bool)"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class MovePoolToNodeArgs:
@@ -354,11 +454,19 @@ class MovePoolToNodeArgs:
     poolAppId: int
     nodeNum: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "movePoolToNode(uint64,uint64,uint64)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class EmptyTokenRewardsArgs:
     """Dataclass for empty_token_rewards arguments"""
     validatorId: int
     receiver: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "emptyTokenRewards(uint64,address)uint64"
 
 
 class ValidatorRegistryParams:
@@ -2345,17 +2453,19 @@ class ValidatorRegistryClient:
 class ValidatorRegistryMethodCallCreateParams(
     algokit_utils.AppClientCreateSchema, algokit_utils.BaseAppClientMethodCallParams[
         typing.Any,
-        typing.Any,
+        str | None,
     ]
 ):
     """Parameters for creating ValidatorRegistry contract using ABI"""
     on_complete: typing.Literal[OnComplete.NoOpOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallCreateParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallCreateParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )

--- a/examples/state/client.py
+++ b/examples/state/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -1657,7 +1657,7 @@ class StateAppMethodCallUpdateParams(
         )
 
 @dataclasses.dataclass(frozen=True)
-class StateAppBareCallUpdateParams(algokit_utils.AppClientBareCallCreateParams):
+class StateAppBareCallUpdateParams(algokit_utils.AppClientBareCallParams):
     """Parameters for calling StateApp contract with bare calls"""
     on_complete: typing.Literal[OnComplete.UpdateApplicationOC] | None = None
 
@@ -1684,7 +1684,7 @@ class StateAppMethodCallDeleteParams(
         )
 
 @dataclasses.dataclass(frozen=True)
-class StateAppBareCallDeleteParams(algokit_utils.AppClientBareCallCreateParams):
+class StateAppBareCallDeleteParams(algokit_utils.AppClientBareCallParams):
     """Parameters for calling StateApp contract with bare calls"""
     on_complete: typing.Literal[OnComplete.DeleteApplicationOC] | None = None
 
@@ -2248,7 +2248,7 @@ class StateAppFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class StateAppFactoryDeleteParams:
@@ -2266,7 +2266,7 @@ class StateAppFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/state/client.py
+++ b/examples/state/client.py
@@ -69,25 +69,45 @@ class CallAbiUint32Args:
     """Dataclass for call_abi_uint32 arguments"""
     input: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "call_abi_uint32(uint32)uint32"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CallAbiUint32ReadonlyArgs:
     """Dataclass for call_abi_uint32_readonly arguments"""
     input: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "call_abi_uint32_readonly(uint32)uint32"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CallAbiUint64Args:
     """Dataclass for call_abi_uint64 arguments"""
     input: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "call_abi_uint64(uint64)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CallAbiUint64ReadonlyArgs:
     """Dataclass for call_abi_uint64_readonly arguments"""
     input: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "call_abi_uint64_readonly(uint64)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CallAbiArgs:
     """Dataclass for call_abi arguments"""
     value: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "call_abi(string)string"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CallAbiTxnArgs:
@@ -95,12 +115,20 @@ class CallAbiTxnArgs:
     txn: algokit_utils.AppMethodCallTransactionArgument
     value: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "call_abi_txn(pay,string)string"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CallWithReferencesArgs:
     """Dataclass for call_with_references arguments"""
     asset: int
     account: str | bytes
     application: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "call_with_references(asset,account,application)uint64"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SetGlobalArgs:
@@ -110,6 +138,10 @@ class SetGlobalArgs:
     bytes1: str
     bytes2: bytes | str | tuple[int, int, int, int]
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "set_global(uint64,uint64,string,byte[4])void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SetLocalArgs:
     """Dataclass for set_local arguments"""
@@ -118,51 +150,91 @@ class SetLocalArgs:
     bytes1: str
     bytes2: bytes | str | tuple[int, int, int, int]
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "set_local(uint64,uint64,string,byte[4])void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SetBoxArgs:
     """Dataclass for set_box arguments"""
     name: bytes | str | tuple[int, int, int, int]
     value: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "set_box(byte[4],string)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DefaultValueArgs:
     """Dataclass for default_value arguments"""
     arg_with_default: str | None = None
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "default_value(string)string"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DefaultValueIntArgs:
     """Dataclass for default_value_int arguments"""
     arg_with_default: int | None = None
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "default_value_int(uint64)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DefaultValueFromAbiArgs:
     """Dataclass for default_value_from_abi arguments"""
     arg_with_default: str | None = None
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "default_value_from_abi(string)string"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DefaultValueFromGlobalStateArgs:
     """Dataclass for default_value_from_global_state arguments"""
     arg_with_default: int | None = None
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "default_value_from_global_state(uint64)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DefaultValueFromLocalStateArgs:
     """Dataclass for default_value_from_local_state arguments"""
     arg_with_default: str | None = None
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "default_value_from_local_state(string)string"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CreateAbiArgs:
     """Dataclass for create_abi arguments"""
     input: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "create_abi(string)string"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class UpdateAbiArgs:
     """Dataclass for update_abi arguments"""
     input: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "update_abi(string)string"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class DeleteAbiArgs:
     """Dataclass for delete_abi arguments"""
     input: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "delete_abi(string)string"
 
 
 class _StateAppUpdate:
@@ -1613,18 +1685,20 @@ class StateAppClient:
 @dataclasses.dataclass(frozen=True)
 class StateAppMethodCallCreateParams(
     algokit_utils.AppClientCreateSchema, algokit_utils.BaseAppClientMethodCallParams[
-        tuple[str] | CreateAbiArgs,
-        typing.Literal["create_abi(string)string"],
+        CreateAbiArgs,
+        str | None,
     ]
 ):
     """Parameters for creating StateApp contract using ABI"""
     on_complete: typing.Literal[OnComplete.NoOpOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallCreateParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallCreateParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )
@@ -1640,18 +1714,20 @@ class StateAppBareCallCreateParams(algokit_utils.AppClientBareCallCreateParams):
 @dataclasses.dataclass(frozen=True)
 class StateAppMethodCallUpdateParams(
     algokit_utils.BaseAppClientMethodCallParams[
-        tuple[str] | UpdateAbiArgs,
-        typing.Literal["update_abi(string)string"],
+        UpdateAbiArgs,
+        str | None,
     ]
 ):
     """Parameters for calling StateApp contract using ABI"""
     on_complete: typing.Literal[OnComplete.UpdateApplicationOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )
@@ -1667,18 +1743,20 @@ class StateAppBareCallUpdateParams(algokit_utils.AppClientBareCallParams):
 @dataclasses.dataclass(frozen=True)
 class StateAppMethodCallDeleteParams(
     algokit_utils.BaseAppClientMethodCallParams[
-        tuple[str] | DeleteAbiArgs,
-        typing.Literal["delete_abi(string)string"],
+        DeleteAbiArgs,
+        str | None,
     ]
 ):
     """Parameters for calling StateApp contract using ABI"""
     on_complete: typing.Literal[OnComplete.DeleteApplicationOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )

--- a/examples/structs/client.py
+++ b/examples/structs/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -909,7 +909,7 @@ class GlobalStateStructFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class GlobalStateStructFactoryDeleteParams:
@@ -927,7 +927,7 @@ class GlobalStateStructFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/structs/client.py
+++ b/examples/structs/client.py
@@ -86,6 +86,10 @@ class HelloArgs:
     """Dataclass for hello arguments"""
     name: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "hello(string)string"
+
 
 class _GlobalStateStructOptIn:
     def __init__(self, app_client: algokit_utils.AppClient):

--- a/examples/voting/client.py
+++ b/examples/voting/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -778,7 +778,7 @@ class VotingRoundAppMethodCallCreateParams(
         )
 
 @dataclasses.dataclass(frozen=True)
-class VotingRoundAppBareCallDeleteParams(algokit_utils.AppClientBareCallCreateParams):
+class VotingRoundAppBareCallDeleteParams(algokit_utils.AppClientBareCallParams):
     """Parameters for calling VotingRoundApp contract with bare calls"""
     on_complete: typing.Literal[OnComplete.DeleteApplicationOC] | None = None
 
@@ -1043,7 +1043,7 @@ class VotingRoundAppFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class VotingRoundAppFactoryDeleteParams:
@@ -1061,7 +1061,7 @@ class VotingRoundAppFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/voting/client.py
+++ b/examples/voting/client.py
@@ -78,10 +78,18 @@ class BootstrapArgs:
     """Dataclass for bootstrap arguments"""
     fund_min_bal_req: algokit_utils.AppMethodCallTransactionArgument
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "bootstrap(pay)void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetPreconditionsArgs:
     """Dataclass for get_preconditions arguments"""
     signature: bytes | str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "get_preconditions(byte[])(uint64,uint64,uint64,uint64)"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class VoteArgs:
@@ -89,6 +97,10 @@ class VoteArgs:
     fund_min_bal_req: algokit_utils.AppMethodCallTransactionArgument
     signature: bytes | str
     answer_ids: list[int]
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "vote(pay,byte[],uint8[])void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CreateArgs:
@@ -101,6 +113,10 @@ class CreateArgs:
     option_counts: list[int]
     quorum: int
     nft_image_url: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "create(string,byte[],string,uint64,uint64,uint8[],uint64,string)void"
 
 
 class _VotingRoundAppDelete:
@@ -761,18 +777,20 @@ class VotingRoundAppClient:
 @dataclasses.dataclass(frozen=True)
 class VotingRoundAppMethodCallCreateParams(
     algokit_utils.AppClientCreateSchema, algokit_utils.BaseAppClientMethodCallParams[
-        tuple[str, bytes | str, str, int, int, list[int], int, str] | CreateArgs,
-        typing.Literal["create(string,byte[],string,uint64,uint64,uint8[],uint64,string)void"],
+        CreateArgs,
+        str | None,
     ]
 ):
     """Parameters for creating VotingRoundApp contract using ABI"""
     on_complete: typing.Literal[OnComplete.NoOpOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallCreateParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallCreateParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )

--- a/examples/zero_coupon_bond/client.py
+++ b/examples/zero_coupon_bond/client.py
@@ -59,7 +59,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)
@@ -1825,7 +1825,7 @@ class ZeroCouponBondMethodCallCreateParams(
         )
 
 @dataclasses.dataclass(frozen=True)
-class ZeroCouponBondBareCallUpdateParams(algokit_utils.AppClientBareCallCreateParams):
+class ZeroCouponBondBareCallUpdateParams(algokit_utils.AppClientBareCallParams):
     """Parameters for calling ZeroCouponBond contract with bare calls"""
     on_complete: typing.Literal[OnComplete.UpdateApplicationOC] | None = None
 
@@ -2387,7 +2387,7 @@ class ZeroCouponBondFactoryUpdateParams:
         """Updates an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_update(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 class ZeroCouponBondFactoryDeleteParams:
@@ -2405,7 +2405,7 @@ class ZeroCouponBondFactoryDeleteParams:
         """Deletes an instance using a bare call"""
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.deploy_delete(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.AppClientBareCallParams(**dataclasses.asdict(params)),
             )
 
 

--- a/examples/zero_coupon_bond/client.py
+++ b/examples/zero_coupon_bond/client.py
@@ -149,11 +149,19 @@ class AssetTransferArgs:
     receiver_holding_address: str
     units: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "asset_transfer(address,address,uint64)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class PayPrincipalArgs:
     """Dataclass for pay_principal arguments"""
     holding_address: str
     payment_info: bytes | str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "pay_principal(address,byte[])(uint64,uint64,byte[])"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetAccountUnitsCurrentValueArgs:
@@ -161,10 +169,18 @@ class GetAccountUnitsCurrentValueArgs:
     holding_address: str
     units: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "get_account_units_current_value(address,uint64)(uint64,uint64,(uint64,uint64))"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetPaymentAmountArgs:
     """Dataclass for get_payment_amount arguments"""
     holding_address: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "get_payment_amount(address)(uint64,uint64)"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class AssetConfigArgs:
@@ -179,10 +195,18 @@ class AssetConfigArgs:
     time_events: list[int]
     time_periods: list[tuple[int, int]]
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "asset_config(uint64,uint64,uint64,uint64,uint8,uint16,uint16[],uint64[],(uint64,uint64)[])void"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SetSecondaryTimeEventsArgs:
     """Dataclass for set_secondary_time_events arguments"""
     secondary_market_time_events: list[int]
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "set_secondary_time_events(uint64[])(uint64,uint64)"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class AssignRoleArgs:
@@ -191,11 +215,19 @@ class AssignRoleArgs:
     role: int
     config: bytes | str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "assign_role(address,uint8,byte[])uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class RevokeRoleArgs:
     """Dataclass for revoke_role arguments"""
     role_address: str
     role: int
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "revoke_role(address,uint8)uint64"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class OpenAccountArgs:
@@ -203,10 +235,18 @@ class OpenAccountArgs:
     holding_address: str
     payment_address: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "open_account(address,address)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class CloseAccountArgs:
     """Dataclass for close_account arguments"""
     holding_address: str
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "close_account(address)(uint64,uint64)"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class PrimaryDistributionArgs:
@@ -214,10 +254,18 @@ class PrimaryDistributionArgs:
     holding_address: str
     units: int
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "primary_distribution(address,uint64)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SetAssetSuspensionArgs:
     """Dataclass for set_asset_suspension arguments"""
     suspended: bool
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "set_asset_suspension(bool)uint64"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SetAccountSuspensionArgs:
@@ -225,21 +273,37 @@ class SetAccountSuspensionArgs:
     holding_address: str
     suspended: bool
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "set_account_suspension(address,bool)uint64"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SetDefaultStatusArgs:
     """Dataclass for set_default_status arguments"""
     defaulted: bool
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "set_default_status(bool)void"
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GetAccountInfoArgs:
     """Dataclass for get_account_info arguments"""
     holding_address: str
 
+    @property
+    def abi_method_signature(self) -> str:
+        return "get_account_info(address)(address,uint64,uint64,uint64,bool)"
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class AssetCreateArgs:
     """Dataclass for asset_create arguments"""
     arranger: str
     metadata: AssetMetadata
+
+    @property
+    def abi_method_signature(self) -> str:
+        return "asset_create(address,(uint8,uint8,uint8,uint8,uint8,uint8,byte[32],string))void"
 
 
 class _ZeroCouponBondUpdate:
@@ -1808,18 +1872,20 @@ class ZeroCouponBondClient:
 @dataclasses.dataclass(frozen=True)
 class ZeroCouponBondMethodCallCreateParams(
     algokit_utils.AppClientCreateSchema, algokit_utils.BaseAppClientMethodCallParams[
-        tuple[str, AssetMetadata] | AssetCreateArgs,
-        typing.Literal["asset_create(address,(uint8,uint8,uint8,uint8,uint8,uint8,byte[32],string))void"],
+        AssetCreateArgs,
+        str | None,
     ]
 ):
     """Parameters for creating ZeroCouponBond contract using ABI"""
     on_complete: typing.Literal[OnComplete.NoOpOC] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCallCreateParams:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCallCreateParams(
             **{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,12 +2,12 @@
 
 [[package]]
 name = "algokit-utils"
-version = "3.0.0b4"
+version = "3.0.0b5"
 description = "Utilities for Algorand development for use by AlgoKit"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "algokit_utils-3.0.0b4-py3-none-any.whl", hash = "sha256:ff6ad8551d93a8b1babe216c35022deaf142212b148b3dfc82ebd40bf0808ce3"},
+    {file = "algokit_utils-3.0.0b5-py3-none-any.whl", hash = "sha256:2208fe123df98c728dc90038bdf8cf8faec8e098f7e747c4e6fc0b9b9fb5498c"},
 ]
 
 [package.dependencies]
@@ -86,13 +86,13 @@ redis = ["redis (>=2.10.5)"]
 
 [[package]]
 name = "certifi"
-version = "2024.12.14"
+version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
-    {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
+    {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
+    {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
 ]
 
 [[package]]
@@ -547,18 +547,18 @@ testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
 name = "filelock"
-version = "3.16.1"
+version = "3.17.0"
 description = "A platform independent file lock."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
-    {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
+    {file = "filelock-3.17.0-py3-none-any.whl", hash = "sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338"},
+    {file = "filelock-3.17.0.tar.gz", hash = "sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e"},
 ]
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4.1)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "pytest (>=8.3.3)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.4)"]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)", "pytest (>=8.3.4)", "pytest-asyncio (>=0.25.2)", "pytest-cov (>=6)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.28.1)"]
 typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
@@ -672,13 +672,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "identify"
-version = "2.6.5"
+version = "2.6.6"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "identify-2.6.5-py2.py3-none-any.whl", hash = "sha256:14181a47091eb75b337af4c23078c9d09225cd4c48929f521f3bf16b09d02566"},
-    {file = "identify-2.6.5.tar.gz", hash = "sha256:c10b33f250e5bba374fae86fb57f3adcebf1161bce7cdf92031915fd480c13bc"},
+    {file = "identify-2.6.6-py2.py3-none-any.whl", hash = "sha256:cbd1810bce79f8b671ecb20f53ee0ae8e86ae84b557de31d89709dc2a48ba881"},
+    {file = "identify-2.6.6.tar.gz", hash = "sha256:7bec12768ed44ea4761efb47806f0a41f86e7c0a5fdf5950d4648c90eca7e251"},
 ]
 
 [package.extras]
@@ -700,13 +700,13 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "importlib-metadata"
-version = "8.5.0"
+version = "8.6.1"
 description = "Read metadata from Python packages"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
-    {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
+    {file = "importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e"},
+    {file = "importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580"},
 ]
 
 [package.dependencies]
@@ -718,7 +718,7 @@ cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 enabler = ["pytest-enabler (>=2.2)"]
 perf = ["ipython"]
-test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
+test = ["flufl.flake8", "importlib_resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
 type = ["pytest-mypy"]
 
 [[package]]
@@ -847,13 +847,13 @@ type = ["pygobject-stubs", "pytest-mypy", "shtab", "types-pywin32"]
 
 [[package]]
 name = "license-expression"
-version = "30.4.0"
+version = "30.4.1"
 description = "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "license_expression-30.4.0-py3-none-any.whl", hash = "sha256:7c8f240c6e20d759cb8455e49cb44a923d9e25c436bf48d7e5b8eea660782c04"},
-    {file = "license_expression-30.4.0.tar.gz", hash = "sha256:6464397f8ed4353cc778999caec43b099f8d8d5b335f282e26a9eb9435522f05"},
+    {file = "license_expression-30.4.1-py3-none-any.whl", hash = "sha256:679646bc3261a17690494a3e1cada446e5ee342dbd87dcfa4a0c24cc5dce13ee"},
+    {file = "license_expression-30.4.1.tar.gz", hash = "sha256:9f02105f9e0fcecba6a85dfbbed7d94ea1c3a70cf23ddbfb5adf3438a6f6fce0"},
 ]
 
 [package.dependencies]
@@ -900,13 +900,13 @@ files = [
 
 [[package]]
 name = "more-itertools"
-version = "10.5.0"
+version = "10.6.0"
 description = "More routines for operating on iterables, beyond itertools"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "more-itertools-10.5.0.tar.gz", hash = "sha256:5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6"},
-    {file = "more_itertools-10.5.0-py3-none-any.whl", hash = "sha256:037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef"},
+    {file = "more-itertools-10.6.0.tar.gz", hash = "sha256:2cd7fad1009c31cc9fb6a035108509e6547547a7a738374f10bd49a09eb3ee3b"},
+    {file = "more_itertools-10.6.0-py3-none-any.whl", hash = "sha256:6eb054cb4b6db1473f6e15fcc676a08e4732548acd47c708f0e179c2c7c01e89"},
 ]
 
 [[package]]
@@ -984,49 +984,43 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.14.1"
+version = "1.15.0"
 description = "Optional static typing for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "mypy-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb"},
-    {file = "mypy-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0"},
-    {file = "mypy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90716d8b2d1f4cd503309788e51366f07c56635a3309b0f6a32547eaaa36a64d"},
-    {file = "mypy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae753f5c9fef278bcf12e1a564351764f2a6da579d4a81347e1d5a15819997b"},
-    {file = "mypy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0fe0f5feaafcb04505bcf439e991c6d8f1bf8b15f12b05feeed96e9e7bf1427"},
-    {file = "mypy-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:7d54bd85b925e501c555a3227f3ec0cfc54ee8b6930bd6141ec872d1c572f81f"},
-    {file = "mypy-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f995e511de847791c3b11ed90084a7a0aafdc074ab88c5a9711622fe4751138c"},
-    {file = "mypy-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d64169ec3b8461311f8ce2fd2eb5d33e2d0f2c7b49116259c51d0d96edee48d1"},
-    {file = "mypy-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba24549de7b89b6381b91fbc068d798192b1b5201987070319889e93038967a8"},
-    {file = "mypy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:183cf0a45457d28ff9d758730cd0210419ac27d4d3f285beda038c9083363b1f"},
-    {file = "mypy-1.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f2a0ecc86378f45347f586e4163d1769dd81c5a223d577fe351f26b179e148b1"},
-    {file = "mypy-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:ad3301ebebec9e8ee7135d8e3109ca76c23752bac1e717bc84cd3836b4bf3eae"},
-    {file = "mypy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14"},
-    {file = "mypy-1.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9"},
-    {file = "mypy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11"},
-    {file = "mypy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e"},
-    {file = "mypy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89"},
-    {file = "mypy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b"},
-    {file = "mypy-1.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:92c3ed5afb06c3a8e188cb5da4984cab9ec9a77ba956ee419c68a388b4595255"},
-    {file = "mypy-1.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dbec574648b3e25f43d23577309b16534431db4ddc09fda50841f1e34e64ed34"},
-    {file = "mypy-1.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c6d94b16d62eb3e947281aa7347d78236688e21081f11de976376cf010eb31a"},
-    {file = "mypy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4b19b03fdf54f3c5b2fa474c56b4c13c9dbfb9a2db4370ede7ec11a2c5927d9"},
-    {file = "mypy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0c911fde686394753fff899c409fd4e16e9b294c24bfd5e1ea4675deae1ac6fd"},
-    {file = "mypy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:8b21525cb51671219f5307be85f7e646a153e5acc656e5cebf64bfa076c50107"},
-    {file = "mypy-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7084fb8f1128c76cd9cf68fe5971b37072598e7c31b2f9f95586b65c741a9d31"},
-    {file = "mypy-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f845a00b4f420f693f870eaee5f3e2692fa84cc8514496114649cfa8fd5e2c6"},
-    {file = "mypy-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44bf464499f0e3a2d14d58b54674dee25c031703b2ffc35064bd0df2e0fac319"},
-    {file = "mypy-1.14.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99f27732c0b7dc847adb21c9d47ce57eb48fa33a17bc6d7d5c5e9f9e7ae5bac"},
-    {file = "mypy-1.14.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bce23c7377b43602baa0bd22ea3265c49b9ff0b76eb315d6c34721af4cdf1d9b"},
-    {file = "mypy-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:8edc07eeade7ebc771ff9cf6b211b9a7d93687ff892150cb5692e4f4272b0837"},
-    {file = "mypy-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35"},
-    {file = "mypy-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc"},
-    {file = "mypy-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9"},
-    {file = "mypy-1.14.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:499d6a72fb7e5de92218db961f1a66d5f11783f9ae549d214617edab5d4dbdbb"},
-    {file = "mypy-1.14.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60"},
-    {file = "mypy-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c"},
-    {file = "mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1"},
-    {file = "mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6"},
+    {file = "mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13"},
+    {file = "mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559"},
+    {file = "mypy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be68172e9fd9ad8fb876c6389f16d1c1b5f100ffa779f77b1fb2176fcc9ab95b"},
+    {file = "mypy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7be1e46525adfa0d97681432ee9fcd61a3964c2446795714699a998d193f1a3"},
+    {file = "mypy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2e2c2e6d3593f6451b18588848e66260ff62ccca522dd231cd4dd59b0160668b"},
+    {file = "mypy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:6983aae8b2f653e098edb77f893f7b6aca69f6cffb19b2cc7443f23cce5f4828"},
+    {file = "mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f"},
+    {file = "mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5"},
+    {file = "mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e"},
+    {file = "mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c"},
+    {file = "mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f"},
+    {file = "mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f"},
+    {file = "mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd"},
+    {file = "mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f"},
+    {file = "mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464"},
+    {file = "mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee"},
+    {file = "mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e"},
+    {file = "mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22"},
+    {file = "mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445"},
+    {file = "mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d"},
+    {file = "mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5"},
+    {file = "mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036"},
+    {file = "mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357"},
+    {file = "mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf"},
+    {file = "mypy-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e601a7fa172c2131bff456bb3ee08a88360760d0d2f8cbd7a75a65497e2df078"},
+    {file = "mypy-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:712e962a6357634fef20412699a3655c610110e01cdaa6180acec7fc9f8513ba"},
+    {file = "mypy-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5"},
+    {file = "mypy-1.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f8722560a14cde92fdb1e31597760dc35f9f5524cce17836c0d22841830fd5b"},
+    {file = "mypy-1.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fbb8da62dc352133d7d7ca90ed2fb0e9d42bb1a32724c287d3c76c58cbaa9c2"},
+    {file = "mypy-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:d10d994b41fb3497719bbf866f227b3489048ea4bbbb5015357db306249f7980"},
+    {file = "mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e"},
+    {file = "mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43"},
 ]
 
 [package.dependencies]
@@ -1137,13 +1131,13 @@ files = [
 
 [[package]]
 name = "pip"
-version = "24.3.1"
+version = "25.0"
 description = "The PyPA recommended tool for installing Python packages."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pip-24.3.1-py3-none-any.whl", hash = "sha256:3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed"},
-    {file = "pip-24.3.1.tar.gz", hash = "sha256:ebcb60557f2aefabc2e0f918751cd24ea0d56d8ec5445fe1807f1d2109660b99"},
+    {file = "pip-25.0-py3-none-any.whl", hash = "sha256:b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65"},
+    {file = "pip-25.0.tar.gz", hash = "sha256:8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b"},
 ]
 
 [[package]]
@@ -1682,13 +1676,13 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "rfc3986"
-version = "1.5.0"
+version = "2.0.0"
 description = "Validating URI References per RFC 3986"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 files = [
-    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
-    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
+    {file = "rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd"},
+    {file = "rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"},
 ]
 
 [package.extras]
@@ -1981,13 +1975,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.28.1"
+version = "20.29.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb"},
-    {file = "virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329"},
+    {file = "virtualenv-20.29.1-py3-none-any.whl", hash = "sha256:4e4cb403c0b0da39e13b46b1b2476e505cb0046b25f242bee80f62bf990b2779"},
+    {file = "virtualenv-20.29.1.tar.gz", hash = "sha256:b8b8970138d32fb606192cb97f6cd4bb644fa486be9308fb9b63f81091b5dc35"},
 ]
 
 [package.dependencies]
@@ -2046,4 +2040,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "0ecc635af048cb4ba6190fa982efa577f8625482e7b192e57ff01a21c9d0e45c"
+content-hash = "7c1cc07b358bf53994ac99f62368c968fa88410bde4f8c9dd539f58d9047da25"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-algokit-utils = "v3.0.0b4"
+algokit-utils = "^v3.0.0b5"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.8.6"

--- a/src/algokit_client_generator/generators/helpers.py
+++ b/src/algokit_client_generator/generators/helpers.py
@@ -55,7 +55,7 @@ def _init_dataclass(cls: type, data: dict) -> object:
         field_value = data.get(field.name)
         # Check if the field expects another dataclass and the value is a dict.
         if dataclasses.is_dataclass(field.type) and isinstance(field_value, dict):
-            field_values[field.name] = _init_dataclass(field.type, field_value)
+            field_values[field.name] = _init_dataclass(typing.cast(type, field.type), field_value)
         else:
             field_values[field.name] = field_value
     return cls(**field_values)

--- a/src/algokit_client_generator/generators/typed_client.py
+++ b/src/algokit_client_generator/generators/typed_client.py
@@ -384,11 +384,11 @@ def generate_structs_for_args(context: GeneratorContext) -> DocumentParts:
             if not has_appl_to_right and is_appl_type:
                 has_appl_to_right = True
 
-        typed_dict_name = f"{context.sanitizer.make_safe_type_identifier(method.abi.client_method_name)}Args"
+        data_class_name = f"{context.sanitizer.make_safe_type_identifier(method.abi.client_method_name)}Args"
 
         yield utils.indented(f"""
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class {typed_dict_name}:
+class {data_class_name}:
     \"\"\"Dataclass for {method.abi.client_method_name} arguments\"\"\"
 """)
         yield Part.IncIndent
@@ -398,7 +398,11 @@ class {typed_dict_name}:
             is_optional = arg.has_default or arg.name in optional_args
             python_type = f"{arg.python_type} | None = None" if is_optional else arg.python_type
             yield f"{arg.name}: {python_type}"
-
+        yield Part.Gap1
+        yield f"""@property
+    def abi_method_signature(self) -> str:
+        return "{method.abi.method.get_signature()}"
+"""
         yield Part.DecIndent
 
 

--- a/src/algokit_client_generator/generators/typed_factory.py
+++ b/src/algokit_client_generator/generators/typed_factory.py
@@ -256,20 +256,10 @@ def _generate_abi_params_class(
 ) -> Iterator[DocumentParts]:
     """Generate ABI params class with proper indentation"""
     # Build method signature and args unions
-    method_data = []
+    args_dataclasses = []
     for method in abi_methods:
         if method.abi and method.abi.args:
-            args_type = f"tuple[{', '.join(arg.python_type for arg in method.abi.args)}]"
-            args_union = (
-                f"{args_type} | {context.sanitizer.make_safe_type_identifier(method.abi.client_method_name)}Args"
-            )
-            method_sig = f'typing.Literal["{method.abi.method.get_signature()}"]'
-            method_data.append((args_union, method_sig))
-
-    args_unions: tuple[str, ...] = ()
-    method_signatures: tuple[str, ...] = ()
-    if method_data:
-        args_unions, method_signatures = zip(*method_data, strict=False)
+            args_dataclasses.append(f"{context.sanitizer.make_safe_type_identifier(method.abi.client_method_name)}Args")
 
     # Get unique on_complete values
     on_completes = {
@@ -280,8 +270,7 @@ def _generate_abi_params_class(
 
     class_name = f"{context.contract_name}MethodCall{type_suffix}Params"
     create_schema = "algokit_utils.AppClientCreateSchema, " if is_create else ""
-    args_union_str = " | ".join(args_unions) if args_unions else "typing.Any"
-    method_sig_str = " | ".join(method_signatures) if method_signatures else "typing.Any"
+    args_union_str = " | ".join(args_dataclasses) if args_dataclasses else "typing.Any"
     on_complete_str = ", ".join(sorted(on_completes))
 
     yield utils.indented(f"""
@@ -289,17 +278,19 @@ def _generate_abi_params_class(
 class {class_name}(
     {create_schema}algokit_utils.BaseAppClientMethodCallParams[
         {args_union_str},
-        {method_sig_str},
+        str | None,
     ]
 ):
     \"\"\"Parameters for {'creating' if is_create else 'calling'} {context.contract_name} contract using ABI\"\"\"
     on_complete: typing.Literal[{on_complete_str}] | None = None
+    method: str | None = None
 
     def to_algokit_utils_params(self) -> algokit_utils.AppClientMethodCall{'Create' if is_create else ''}Params:
         method_args = _parse_abi_args(self.args)
         return algokit_utils.AppClientMethodCall{'Create' if is_create else ''}Params(
             **{{
                 **self.__dict__,
+                "method": self.method or getattr(self.args, "abi_method_signature", None),
                 "args": method_args,
             }}
         )

--- a/src/algokit_client_generator/generators/typed_factory.py
+++ b/src/algokit_client_generator/generators/typed_factory.py
@@ -147,6 +147,7 @@ def _generate_operation_params_class(context: GeneratorContext, operation: str) 
     class_name = f"{context.contract_name}Factory{operation.title()}Params"
     method_name = "create" if operation == "create" else f"deploy_{operation}"
 
+    bare_params_class = "AppFactoryCreateParams" if operation == "create" else "AppClientBareCallParams"
     yield utils.indented(f"""
 class {class_name}:
     \"\"\"Parameters for '{operation}' operations of {context.contract_name} contract\"\"\"
@@ -163,7 +164,7 @@ class {class_name}:
         \"\"\"{operation.title()}s an instance using a bare call\"\"\"
         params = params or algokit_utils.CommonAppCallCreateParams()
         return self.app_factory.params.bare.{method_name}(
-            algokit_utils.AppFactoryCreateParams(**dataclasses.asdict(params)),
+            algokit_utils.{bare_params_class}(**dataclasses.asdict(params)),
             {'compilation_params=compilation_params' if operation == 'create' else ''})
 """)
 
@@ -316,10 +317,10 @@ def _generate_bare_params_class(
     )
 
     class_name = f"{context.contract_name}BareCall{type_suffix}Params"
-
+    sub_class = "AppClientBareCallCreateParams" if is_create else "AppClientBareCallParams"
     yield utils.indented(f"""
 @dataclasses.dataclass(frozen=True)
-class {class_name}(algokit_utils.AppClientBareCallCreateParams):
+class {class_name}(algokit_utils.{sub_class}):
     \"\"\"Parameters for {'creating' if is_create else 'calling'} {context.contract_name} contract with bare calls\"\"\"
     on_complete: typing.Literal[{on_complete_options}] | None = None
 


### PR DESCRIPTION
## Proposed Changes

  - Minor fixes to resolve mypy errors when used with lint command in python template
  - Based on feedback from @cusma , removes the requirement to explicitly pass `method` argument in dataclass for create,update,delete params in factory deploy method:
  - - Additionally avoids a bug in VSCode where string literals of long len wouldn't get autocompleted https://github.com/microsoft/pylance-release/issues/5116. Note that bug in VSCode was uncovered as part of addressing Cosimo's feedback, hence adding extra argument towards removing requirement to pass `method` explicitly. 
  - - Removes union types from args field, requiring explicit dataclasses when dealing with deploy method in order to figure out the signature (which now gets generated in `abi_method_signature` property on all args dataclasses) -> aligns further with the approach used in v1 of generators.
