### PR TITLE
fix: correcting the ignore declaration for a more appropriate mypy global ignore

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -10,8 +10,8 @@ def enable_mypy(approved_path: pathlib.Path) -> None:
     # Read the file text with line endings preserved
     lines = approved_path.read_text().splitlines(keepends=True)
     assert (
-        lines[2] == "# type: ignore\n"
-    ), f"Expected third line to be '# type: ignore', got {lines[2]!r} in {approved_path}"
+        lines[2] == "# mypy: ignore-errors\n"
+    ), f"Expected third line to be '# mypy: ignore-errors', got {lines[2]!r} in {approved_path}"
     # Replace the third line with the updated mypy comment
     lines[2] = '# mypy: disable-error-code="no-any-return, no-untyped-call, misc, type-arg"\n'
     approved_path.write_text("".join(lines))

--- a/src/algokit_client_generator/generators/header_comments.py
+++ b/src/algokit_client_generator/generators/header_comments.py
@@ -5,7 +5,8 @@ from algokit_client_generator.document import DocumentParts
 def disable_linting() -> DocumentParts:
     yield "# flake8: noqa"  # this works for flake8 and ruff
     yield "# fmt: off"  # disable formatting
-    yield "# type: ignore"  # disable common type warnings
+    # https://mypy.readthedocs.io/en/stable/common_issues.html#ignoring-a-whole-file
+    yield "# mypy: ignore-errors"  # ignore common mypy warnings
 
 
 def generate_header_comments(context: GeneratorContext) -> DocumentParts:


### PR DESCRIPTION
# Propose changes

A follow fix to replace global mypy ignore with a recommended option as per mypy docs. Previous use of type: ignore was too permissive and disabling the mypy on file in a manner that would break ability to interact with abstractions imported from the file within projects that rely on mypy (making all of the abstractions untyped). This ignore statement instead fixes the problem and is a highlighted as a relevant option in mypy docs. 