### PR TITLE
chore: enable dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
+  - package-ecosystem: 'pip'
     directory: '/'
     schedule:
       interval: 'weekly'
     commit-message:
       prefix: 'chore(deps)'
     groups:
-      all:
-        patterns:
-          - '*'
+      minor-and-patch:
         update-types:
           - 'minor'
           - 'patch'


### PR DESCRIPTION
Since #40, we rely on `mypy` being the latest version possible to catch issues on the generated client upstream instead of on the user's project.

This PR enables a weekly dependabot check which will eventually propose a new version of `mypy` through a PR to main. This will run the CI checks which will autonomously validate if the generated client needs to be fixed.