### PR TITLE
ci: add cd for alpha branch

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - alpha
     paths-ignore:
       - "docs/**"
   workflow_dispatch:
@@ -48,16 +49,17 @@ jobs:
           app-id: ${{ secrets.BOT_ID }}
           private-key: ${{ secrets.BOT_SK }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Fetch entire repository history so we can determine version number from it
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Install poetry
         run: pipx install poetry
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: "poetry"
@@ -70,10 +72,20 @@ jobs:
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: get_branch
 
-      - name: Set Git user
+      - name: Set Git user as GitHub actions
+        run: git config --global user.email "179917785+engineering-ci[bot]@users.noreply.github.com" && git config --global user.name "engineering-ci[bot]"
+
+      - name: Create Continuous Deployment - Alpha
+        if: steps.get_branch.outputs.branch == 'alpha'
         run: |
-          git config user.name "engineering-ci[bot]"
-          git config user.email "179917785+engineering-ci[bot]@users.noreply.github.com"
+          poetry run semantic-release \
+            -v DEBUG \
+            --prerelease \
+            --define=prerelease_tag=alpha \
+            --define=branch=alpha \
+            publish
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
 
       - name: Create Continuous Deployment - Beta (non-prod)
         if: steps.get_branch.outputs.branch == 'main' && !inputs.production_release
@@ -83,7 +95,6 @@ jobs:
             --prerelease \
             --define=branch=main \
             publish
-          gh release edit --prerelease "v$(poetry run semantic-release print-version --current)"
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -649,20 +649,15 @@ testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
 name = "filelock"
-version = "3.17.0"
+version = "3.20.1"
 description = "A platform independent file lock."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "filelock-3.17.0-py3-none-any.whl", hash = "sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338"},
-    {file = "filelock-3.17.0.tar.gz", hash = "sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e"},
+    {file = "filelock-3.20.1-py3-none-any.whl", hash = "sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a"},
+    {file = "filelock-3.20.1.tar.gz", hash = "sha256:b8360948b351b80f420878d8516519a2204b07aefcdcfd24912a5d33127f188c"},
 ]
-
-[package.extras]
-docs = ["furo (>=2024.8.6)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)", "pytest (>=8.3.4)", "pytest-asyncio (>=0.25.2)", "pytest-cov (>=6)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.28.1)"]
-typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
 name = "gitdb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,21 @@ suppress-none-returning = true
 [tool.poe.tasks]
 update-approvals = "poetry run python -m scripts.update_approvals"
 
+[tool.poe.tasks.release-preview]
+sequence = [
+  { cmd = "semantic-release print-version --current" },
+  { cmd = "semantic-release print-version --prerelease" },
+]
+help = "Preview current and next prerelease version"
+
+[tool.poe.tasks.release-dry-run-alpha]
+shell = "semantic-release -v DEBUG --noop --prerelease --define=prerelease_tag=alpha publish"
+help = "Dry-run alpha release (no changes made)"
+
+[tool.poe.tasks.release-dry-run-beta]
+shell = "semantic-release -v DEBUG --noop --prerelease --define=prerelease_tag=beta publish"
+help = "Dry-run beta release (no changes made)"
+
 [tool.pytest.ini_options]
 pythonpath = ["src", "tests"]
 


### PR DESCRIPTION
This pull request updates the continuous deployment workflow to support alpha releases and improves release tooling for previewing and dry-running releases. The most important changes are grouped below.

**Continuous Deployment Workflow Enhancements:**

* The GitHub Actions workflow now triggers on pushes to both the `main` and `alpha` branches, enabling separate deployment flows for each.
* Added a dedicated job to perform continuous deployment for the `alpha` branch, using `semantic-release` with the `alpha` prerelease tag and branch configuration.
* Upgraded `actions/checkout` to v4 and `actions/setup-python` to v5 for improved performance and security. Also, the workflow now checks out code using the generated app token for better permissions handling.
* Improved the Git user setup step for CI consistency and clarity.
* Minor cleanup in the main release step by removing an unnecessary `gh release edit` command.

**Release Tooling Improvements:**

* Added new `poe` tasks in `pyproject.toml` to preview current and next prerelease versions, and to perform dry-run alpha and beta releases without making any changes. These tasks aid in safer and more transparent release management.Fixes #
